### PR TITLE
Update build.xml to add guava to the classpath

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -225,6 +225,7 @@
     <fileset dir="${tools.lib.dir}">
       <include name="*.jar" />
     </fileset>
+    <fileset id="fs" dir="${packaged.lib.dir}" includes="${guava.jar}"/>
     <pathelement path="${pigtestclasses.dir}" />
   </path>
 


### PR DESCRIPTION
The datafu jar does not include the correct path to com.google.common.base.Function which causes the tests to fail.

The error can be resolved by adding guava jar to build.xml under `<path id="run-tests-base-classpath">`
On adding `<fileset id="fs" dir="${packaged.lib.dir}" includes="${guava.jar}"/>` , all the tests run successfully.

Resolves #1 
